### PR TITLE
Fix broken Tools link and rename to Useful Links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,8 +235,8 @@ const config = {
                 to: '/docs/get-started',
               },
               {
-                label: 'Tools',
-                to: '/docs/events/useful-links',
+                label: 'Useful Links',
+                to: '/docs/useful-links',
               },
               {
                 label: 'GitHub',


### PR DESCRIPTION
- Fixed broken footer link that pointed to /docs/events/useful-links
- Updated label to “Useful Links” and path to correct location in /docs/useful-links.md