### PR TITLE
Trigger rebuild to deploy CEUR template

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,3 +1,4 @@
+// Trigger rebuild to deploy CEUR template ZIP
 // @ts-check
 // `@type` JSDoc annotations allow editor autocompletion and type checking
 // (when paired with `@ts-check`).


### PR DESCRIPTION
Added a comment to docusaurus.config.js to force a new deployment. This ensures the /documents/CEUR-Template-Bundle.zip file becomes available on the live site.