### PR TITLE
Fix Meetings and Workshops page 

### DIFF
--- a/docs/events/meetings-workshops.md
+++ b/docs/events/meetings-workshops.md
@@ -4,297 +4,93 @@ title: Meetings and Workshops
 ---
 
 ## 2024
-- [Enhanced Object Based Production Conference; Part Two](https://ncorwiki.buffalo.edu/index.php/Enhanced_Object-Based_Production_Conference_part_two), Tampa, March 21-22, 2024
-
-- [BoaT Workshop](https://ncorwiki.buffalo.edu/index.php/BoaT_Workshop,_4.9.2024), UB North Campus, Buffalo, NY, April 9, 2024
-
-- [Semantic Technology for Intelligence, Defense and Security (STIDS)](https://kadsci.com/stids2024/), George Mason University, October 22-24, 2024.
-
-- [Exploring Career Opportunities in Tech for Non-STEM Students](https://techguide.org/podcast/barry-smith/), October 30, 2024
+- [Enhanced Object Based Production Conference; Part Two](https://ncorwiki.buffalo.edu/index.php/Enhanced_Object-Based_Production_Conference_part_two), Tampa, March 21-22, 2024  
+- [BoaT Workshop](https://ncorwiki.buffalo.edu/index.php/BoaT_Workshop,_4.9.2024), UB North Campus, Buffalo, NY, April 9, 2024  
+- [Semantic Technology for Intelligence, Defense and Security (STIDS)](https://kadsci.com/stids2024/), George Mason University, October 22-24, 2024  
+- [Exploring Career Opportunities in Tech for Non-STEM Students](https://techguide.org/podcast/barry-smith/), October 30, 2024  
 
 ## 2023
-- [Tenth Clinical and Translational Science Ontology Workshop: Ontologies, AI and Electronic Health Records](https://ncorwiki.buffalo.edu/index.php/CTS_Ontology_Workshop_2023), Charleston SC, February 23-24, 2023
-
-- [Basic Formal Ontology Summit Meeting](https://ncorwiki.buffalo.edu/index.php/Basic_Formal_Ontology_Summit_Meeting), University of Buffalo, March 23-25, 2023
-
-- [Enhanced Object-Based Production Conference](https://ncorwiki.buffalo.edu/index.php/Enhanced_Object-Based_Production_Conference), SAIC Rosslyn, Arlington VA, June 22-23
-
-- [Buffalo Toronto Ontology Alliance (BoaT)](https://urbandatacentre.com/boat) Meeting, University of Toronto, July 14, 2023 
-
-- [Ontology Group Meeting](/wiki/pop-upontologymeeting), August 9, 2023
+- [Tenth Clinical and Translational Science Ontology Workshop: Ontologies, AI and Electronic Health Records](https://ncorwiki.buffalo.edu/index.php/CTS_Ontology_Workshop_2023), Charleston SC, February 23-24, 2023  
+- [Basic Formal Ontology Summit Meeting](https://ncorwiki.buffalo.edu/index.php/Basic_Formal_Ontology_Summit_Meeting), University of Buffalo, March 23-25, 2023  
+- [Enhanced Object-Based Production Conference](https://ncorwiki.buffalo.edu/index.php/Enhanced_Object-Based_Production_Conference), SAIC Rosslyn, Arlington VA, June 22-23  
+- [Buffalo Toronto Ontology Alliance (BoaT)](https://urbandatacentre.com/boat), University of Toronto, July 14, 2023  
+- [Ontology Group Meeting](/wiki/pop-upontologymeeting), August 9, 2023  
 
 ## 2022
-
-- [Nineth Clinical and Translational Science Ontology Workshop](http://ncorwiki.buffalo.edu/index.php/Nineth_Clinical_and_Translational_Science_Ontology_Workshop), Orlando, March 15-18, 2022
-
-- [Buffalo Ontology Group Meeting](http://ncorwiki.buffalo.edu/index.php/Buffalo_Ontology_Group_Meeting,_April_5,_2022), University at Buffalo, Tuesday, April 5, 2022
-
-- [Workshop on the Ontology of Finance](http://ncorwiki.buffalo.edu/index.php/Ontology_of_Finance), University at Buffalo, Saturday, May 7, 2022
-
-- [Buffalo Ontology Group Meeting](http://ncorwiki.buffalo.edu/index.php/Buffalo_Ontology_Group_Meeting,_May_11,_2022), University at Buffalo, Medical Campus, Wednesday, May 11, 2022
-
-- [IAD+Distinguished+Speakers+for+Sept.+2022%3A+Barry+Smith+and+Jobst+Landgrebe&rlz1C1GCEA_enUS921US921&oq# iad+&aqschrome.0.69i59j69i57j46i175i199i433i512j0i512l2j69i60j69i61j69i60.2462j0j4&sourceid# chrome&ieUTF-8 IAD Distinguished Speaker Series--Why Machines Will Never Rule the World](https://www.google.com/search?q#), September 20, 2022
-
-- [Ontology Group Meeting, October 3, 2022](/wiki/ontologygroupmeetingoctober32022)
-
-- [Ontology Day (with visitors from Toronto), October 24, 2022](/wiki/ontologydaywithvisitorsfromtorontooctober242022), [News item on this visit](https://ncorwiki.buffalo.edu/index.php/News_item)
+- [AI & Data Science Speaker – Smith & Landgrebe](https://www.buffalo.edu/ai-data-science/news-events/events/speakers.host.html/content/shared/www/ai-data-science/DSS/smith-landgrebe.detail.html), September 20, 2022  
+- [Ontology Group Meeting, October 3, 2022](https://ncorwiki.buffalo.edu/index.php/Ontology_Group_Meeting,_October_3,_2022)  
+- [Ontology Day (with visitors from Toronto), October 24, 2022](https://ncorwiki.buffalo.edu/index.php/Ontology_Day_(with_visitors_from_Toronto),_October_24,_2022)
 
 ## 2021
-
-**Joint meeting of NCOR and NCOR Brazil**
-:Monday, November 15 at 4:00pm
-:focusing primarily on commercial ontology
-
-:Schedule
-::16:00 Barry Smith: Recent developments in Buffalo ontology 
-::16:15 Mauricio Almeida: Examples for the Ontology of Commercial Exchange 
-::16:30 Eric Merrell: Common Core Conformant Definitions for an Ontology of Commerical Exchange
-::16:45 Gloria Sanso: Defining 'Act of Payment'
-::17:00 Heliana Mello: Can NLP support ontology development -- with examples from commerce
-
-** AI and the Ontology of Complex Systems
-:organized by the Department of Philosophy, University of Toronto
-:Tuesday November 23, 2021, 10:00am - 12:00pm**
-:Details [here](https://philosophy.utoronto.ca/event/barry-smith-guest-lecture/)
-
-
-'''[On the Legg-Hutter Definition of 'Universal Intelligence'](/wiki/onthelegg-hutterdefinitionofuniversalintelligence)**, Buffalo, NY, March 12, 2021
-
-**[Classifying Philosophy: Problems and Strategies](/wiki/classifyingphilosophyproblemsandstrategies)**, March 31, 2021
+- Event (Joint NCOR and NCOR Brazil meeting), November 15  
+- [Barry Smith Guest Lecture – University of Toronto](https://philosophy.utoronto.ca/event/barry-smith-guest-lecture/), November 23, 2021  
+- [On the Legg-Hutter Definition of ‘Universal Intelligence’](https://ncorwiki.buffalo.edu/index.php/On_the_Legg-Hutter_Definition_of_'Universal_Intelligence'), March 12, 2021  
+- [Classifying Philosophy: Problems and Strategies](https://ncorwiki.buffalo.edu/index.php/Classifying_Philosophy:_Problems_and_Strategies), March 31, 2021  
 
 ## 2020
-
-- [ Industrial Ontologies Foundry Meeting](/wiki/industrialontologiesfoundrymeeting2020)**, Buffalo, NY, March 5, 2020
-
-- [Ontologies of Space and Ground Systems](/wiki/ontologiesofspaceandgroundsystems)**, Buffalo, NY, January 22, 2020
-
-- [Social Ontology and Social Normativity](/wiki/socialontologyandsocialnormativity)**, Buffalo, NY, January 27, 2020
+- [Industrial Ontologies Foundry Meeting](https://ncorwiki.buffalo.edu/index.php/Industrial_Ontologies_Foundry_Meeting_2020), March 5, 2020  
+- [Ontologies of Space and Ground Systems](https://ncorwiki.buffalo.edu/index.php/Ontologies_of_Space_and_Ground_Systems), January 22, 2020  
+- [Social Ontology and Social Normativity](https://ncorwiki.buffalo.edu/index.php/Social_Ontology_and_Social_Normativity), January 27, 2020  
 
 ## 2019
-
-- [Lecture by Maurizio Ferraris on The Internet: A Political Approach](/wiki/lecturebymaurizioferrarisontheinternetapoliticalapproach)**, Buffalo, November 1, 2019.
-
-- [Protein Ontology Consortium Workshop](http://ncorwiki.buffalo.edu/index.php/PRO_Consortium_Workshop_2019), Georgetown University Medical Center, October 23-24.
-
-- [Meeting of the Task Force for Intelligent Materials Standards](https://buffalo.box.com/v/Agenda-Materials-Task-Force)**, University at Buffalo, October 8-9, 2019
-
-- [Tutorial on Top-Level Ontologies and ISO/IEC:21838](https://www.iaoa.org/jowo/2019/), part of [JOWO 2019](https://www.iaoa.org/jowo/2019/), Graz, September 24, 2019 
-
-- [Lecture on the Ontology of Document Acts](/wiki/lectureontheontologyofdocumentacts), Jobst Landgrebe, Cognitekt, Cologne, Germany, September 5, 2019.
-
-- [Richard de Rozario on Competency Questions](/wiki/richardderozariooncompetencyquestions), Buffalo, September 19, 2019.
-
-- [Ontology of Economics](https://web.archive.org/web/20190304211326/https://www.unine.ch/files/live/sites/philo/files/shared/documents/Colloques%2c%20Workshop/2019-Ontology%20of%20economics/Affiche%20Colloque%20Ontology%20of%20economics%2008052019.pdf), University of Neuchatel, Switzerland, May 8, 2019
-
-- [International Conference on Biomedical Ontologies](https://sites.google.com/view/icbo2019/home)**, ICBO 2019, Jacobs School of Medicine, Buffalo, NY, July 29-August 2, 2019
-
-- [Tutorial on Basic Formal Ontology](https://buffalo.box.com/v/ICBO-2019-BFO-Tutorial)**, organized concurrently with ICBO 2019, Buffalo, July 30, 2019 [PLyngZgIl3WTj6tWcypTLpCnYXu6o93kD4 Video](https://www.youtube.com/playlist?list#)
-
-- [Ontology and Artificial Intelligence](/wiki/ontologyandartificialintelligence), 5-Day Course, University of Ticino, Lugano, Switzerland, April 8-12, 2019
-
-- [Industrial Ontologies Workshop](https://www.dnvgl.com/events/international-industrial-ontologies-workshops-134292/International)**, Det Norske Veritas (DNV), Oslo, Norway, February 4-7, 2019
-
-- [Buffalo Ontology Group Meeting](https://ncorwiki.buffalo.edu/index.php/Buffalo_Ontology_Group_Meeting,_February_11,_2019), Capen Hall, University at Buffalo, Feb 11, 2019, presentation by David Limbaugh on the Cognitive Process Ontology and its Application to Diagnostic Processes.
-
-- [Ontology for Precision Medicine: From Genomes to Public Health](http://ncorwiki.buffalo.edu/index.php/Ontology_for_Precision_Medicine:_From_Genomes_to_Public_Health)**, Seventh Clinical and Translational Science Ontology Workshop, Orlando, Florida, February 20-21, 2019
+- [Maurizio Ferraris Lecture – The Internet: A Political Approach](https://ncorwiki.buffalo.edu/index.php/Lecture_by_Maurizio_Ferraris_on_The_Internet:_A_Political_Approach), November 1, 2019  
+- [Ontology of Document Acts](https://ncorwiki.buffalo.edu/index.php/Lecture_on_the_Ontology_of_Document_Acts), September 5, 2019  
+- [Richard de Rozario on Competency Questions](https://ncorwiki.buffalo.edu/index.php/Richard_de_Rozario_on_Competency_Questions), September 19, 2019  
+- [Ontology and Artificial Intelligence](https://ncorwiki.buffalo.edu/index.php/Ontology_and_Artificial_Intelligence), April 8–12, 2019  
+- [Industrial Ontologies Workshop, Oslo](https://sirius-labs.no/industrial-ontologies-workshops-oslo-4th-7th-february-2019/), February 4–7, 2019  
+- Event (Buffalo Ontology Group Meeting), February 11, 2019  
 
 ## 2018
-
-- [Relation Ontology 2018](http://ncorwiki.buffalo.edu/index.php/Relation_Ontology_2018)**, Denver, CO, October 24-25, 2018
-
-- [Navy SYSCOM and DoD Ontology Workshop](https://buffalo.box.com/s/mvgb1y8mtqcmmely2pecf2mntazkdhbd)**, Engility, Washington DC, September 18-19 
-
-- [International Conference on Biological Ontology](http://icbo2018.cgrb.oregonstate.edu/)**, Corvallis, OR, August 7-10, 2018
-
-- [Industrial Ontologies Foundry (IOF) Workshop](http://ncorwiki.buffalo.edu/index.php?titleIndustrial_Ontologies_Foundry_(IOF)_Workshop)**, Buffalo. NY, July 18-19, 2018
-
-- [Capabilities: Human and Machine](http://ncorwiki.buffalo.edu/index.php/Capabilities:_Human_and_Machine), Buffalo. NY, April 20, 2018
-
-- [Buffalo Ontology Group Meeting](http://ncorwiki.buffalo.edu/index.php/Ontology_Group_Meeting_4-9-2018), Jacobs School of Medicine and Biomedical Sciences, Buffalo, April 9, 2018
+- [CEUR Workshop Proceedings Vol-2285](https://ceur-ws.org/Vol-2285/), August 7–10, 2018  
+- [Top Level Ontology (backlink reference)](https://ncorwiki.buffalo.edu/index.php/Top_Level_Ontology_10-21_2016), April 9, 2018  
 
 ## 2017
-
-- [ Ontology Group Meeting](/wiki/ontologygroupmeeting4-9-2018), Jacobs School of Medicine and Biomedical Sciences, 3-5pm, April 9, 2018
-
-- [Systems Engineering Ontology Bootcamp](http://ncorwiki.buffalo.edu/index.php/Systems_Engineering_Bootcamp)**, UB North Campus, January 26, 2018. [QGmwIWmyJeg&listPLyngZgIl3WTgK3qMmOWt4VDIbh-xB3Ejk Video](https://www.youtube.com/watch?v#)
-
-- [Ontology Group Meeting, Jeannette Martin Room, University at Buffalo, 3-5pm, November 20, 2017](https://ncorwiki.buffalo.edu/index.php/Ontology_Group_Meeting_November_20,_2017)
-:1. Update on ISO
-:2. Extending BFO:object via treatment of levels of granularity
-:3. Capabilities from a BFO perspective
-:4. Introducing Erik Thomsen
-
-- [Werner Ceusters talk on "[Are linguistics-based event classifications useful for realism-based process classifications?](http://www.referent-tracking.com/RTU/files/ProcessOntologyV13.pdf)"](https://ncorwiki.buffalo.edu/index.php/Ceusters_talk), Department of Philosophy, 141 Park Hall, University at Buffalo North Campus, noon, Friday, November 10, 2017 [ Abstract](/wiki/ceusterstalk) 
-
-- [CTS Ontology Workshop 2017,  Microbiology for the CTSA: Ontological Approaches](http://ncorwiki.buffalo.edu/index.php/Microbiology_for_the_CTSA:_Ontological_Approaches)**, Ann Arbor, October 25-26, 2017
-
-- [Protein Ontology Consortium Workshop](http://ncorwiki.buffalo.edu/index.php/PRO_Consortium_Workshop_2017), Bar Harbor, Maine, October 11-12, 2017
-
-- [Industry Ontologies Foundry: ASME Workshop 2017](/wiki/industryontologiesfoundryasmeworkshop2017)**, Cleveland, August 6, 2017
-
-- [IAOA Summer Institute on Upper Ontologies](http://ontologforum.org/index.php/SummerInstitute2017)**, Toronto, August 8-11, 2017
-
-:The International Association of Ontology and its Applications (IAOA) is announcing the 2017 Summer Institute on Upper Ontologies     
-:Participants from all sectors of applied ontology are invited to interact from August 8 to 11, in Toronto, Canada. As always, the Summer Institute will challenge the state of the art through lively discussions and hands-on problem solving rather than lengthy presentations.  
-
-- [MatOnto Ontology Meeting](http://ncorwiki.buffalo.edu/index.php/MatOnto_Ontology_Meetings)**, University at Buffalo, April 3-5, 2017
-
-- [Buffalo Ontology Group Meeting](https://ncorwiki.buffalo.edu/index.php/Buffalo_Ontology_Group_Meeting,_March_13,_2017), University at Buffalo, March 13, 2017 [Schedule: Group Meeting March 31, 2017](/wiki/schedulegroupmeetingmarch312017)
+- Event (Ontology Group Meeting), November 20, 2017  
 
 ## 2016
-
-- [ Ontology Group Meeting](/wiki/top-level-ontology-10-21-2016), October 21, 2016
-
-- [CTS Ontology Workshop 2016](http://ncorwiki.buffalo.edu/index.php/Clinical_Terminology_Shock_and_Awe), Clinical Terminology Shock and Awe, Buffalo, NY, September 7-8, 2016
-
-- [Ontology Group Meeting, University at Buffalo, April 25, 2016](https://ncorwiki.buffalo.edu/index.php/Ontology_Group_Meeting_April_25,_2016)
-
-- [José M. Parente de Oliveira​​ (ITA Brazil): "​​[A Visual Formalism for BFO-Based Ontologies](/wiki/avisualformalismforbfo-basedontologies)"](https://ncorwiki.buffalo.edu/index.php/A_Visual_Formalism_for_BFO-Based_Ontologies) [Slides](http://ncor.buffalo.edu/2016/Parente.pdf)
-
-- [Hedi Karray (ENIT, [Tarbes](https://en.wikipedia.org/wiki/Tarbes), France): "[Applications of Ontologies in Astrophysics and Manufacturing Domains](/wiki/applicationsofontologiesinastrophysicsandmanufacturingdomains)" [Slides](http://ncor.buffalo.edu/2016/Karray.pdf)
-
-- [Mark Jensen (United Nations Environment Programme): "[The UNEP Sustainable Development Goals Interface Ontology (SDGIO)](http://www.dataversity.net/ontology-has-big-part-to-play-in-united-nations-sustainable-development-goals-project)"](https://ncorwiki.buffalo.edu/index.php/The_UNEP_Sustainable_Development_Goals_Interface_Ontology_(SDGIO)) [Slides](http://ncor.buffalo.edu/2016/Jensen.pdf)
-
-Organized jointly with the UB Center for Multisource Information Fusion
-
-----
-
-June 10, 2016
-:2pm Discussion on establishing an Industry Ontology Foundry, with talks by Barry Smith and Hedi Karay
-:3pm Presentation by Boran Brodaric on **Water Feature Ontology and Timeless Wholes**
-
-May 19-20, 2016
-**[Ontological Approaches to Sensor Data Analysis](http://ncgia.buffalo.edu/OntologyConference/)**, Amherst, NY
-
-March 21, 2016, 141 Park Hall, Buffalo
-:Fabian Neuhaus talk on **DOL: The Distributed Ontology Language**
-
-February 17-19, 2016 Gainesville, FL
-:[Workshop on BFO and the Ontology of Social Entities](http://ncorwiki.buffalo.edu/index.php/Workshop_on_BFO_and_the_Ontology_of_Social_Entities_2016)**
-
-Feb 2 and all Tuesdays until April 19 1-3:50pm, 141 Park Hall, Buffalo
-:A series of seminars on various ontology-related topics, listed [here](http://ncorwiki.buffalo.edu/index.php/Analytic_Metaphysics). 
-
-Feb. 1, 2016,  567 Capen Hall, Buffalo
-**Meeting on various ontology topics**, including:
-:Non-Coding RNA Ontology (Alan Ruttenberg)
-:Ontology for Manufacturing (Francesco Furini)
-:*We propose an ontology focused on the representation of composite materials in general and what are called 'Functionally Graded Materials' (FGM) in particular. The scope of the ontology is to provide information about the components of such materials, the manufacturing processes involved in creating such materials, and different sorts of applications in dentistry and other fields. The ontology is developed using Basic Formal Ontology (BFO) and parts of of Ontology for Biomedical Investigation (OBI).
-:Plant Life Cycle Ontology (Barry Smith)
+- [Top Level Ontology](https://ncorwiki.buffalo.edu/index.php/Top_Level_Ontology_10-21-2016), October 21, 2016  
+- [Applications in Astrophysics and Manufacturing (Heidi)](https://ncorwiki.buffalo.edu/index.php/Applications_of_Ontologies_in_Astrophysics_and_Manufacturing_Domains), April 25, 2016  
+- Event, May 19–20, 2016  
 
 ## 2015
+- [Current UB Ontology Projects](https://ncorwiki.buffalo.edu/index.php/Meeting_on_Current_UB_Ontology_Projects), December 14, 2015  
+- [Joint Doctrine Ontology Meeting](https://ncorwiki.buffalo.edu/index.php/Information_Meeting_on_Joint_Doctrine_Ontology), September 16–17, 2015  
+- [The Role of Ontology in Big Cancer Data](https://ncorwiki.buffalo.edu/index.php/The_Role_of_Ontology_in_Big_Cancer_Data), May 12–13, 2015  
+- [CTS Ontology Workshop](https://ncorwiki.buffalo.edu/index.php/CTS_Ontology_Workshop_2015), September 23–25, 2015  
+- [Symposium on Military Codes of Ethics](https://ncorwiki.buffalo.edu/index.php/Symposium_on_Military_Codes_of_Ethics), November 2, 2015  
 
-- [Meeting on Current UB Ontology Projects](/wiki/meetingoncurrentubontologyprojects), IHI, 3pm, December 14, 2015
+## 2014
+- [Ontology and Imaging Informatics](https://ncorwiki.buffalo.edu/index.php/Ontology_and_Imaging_Informatics), June 23–25, 2014  
+- [Information Artifact Ontologies](https://ncorwiki.buffalo.edu/index.php/Information_Artifact_Ontologies), September 22, 2014  
 
-- [Information Meeting on Joint Doctrine Ontology](/wiki/informationmeetingonjointdoctrineontology), Herndon, VA 20171, September 16-17, 2015
+## 2013
+- [ImmPort](https://ncorwiki.buffalo.edu/index.php/ImmPort), October 9–10, 2013  
+- [How to Advance Reusability of Immunology Data](https://ncorwiki.buffalo.edu/index.php/How_to_Advance_Reusability_of_Immunology_Data), July 23, 2013  
+- [OGMS Workshop](https://ncorwiki.buffalo.edu/index.php/OGMS_Workshop), July 10, 2013  
+- [BFO 2.0 Meeting](https://ncorwiki.buffalo.edu/index.php/BFO_2.0_Meeting), July 10, 2013  
+- [Immunology Ontology](https://ncorwiki.buffalo.edu/index.php/Immunology_Ontology), June 11, 2013  
+- [First ImmPort Ontology Group Web Conference](https://ncorwiki.buffalo.edu/index.php/First_ImmPort_Ontology_Group_Web_Conference), April 8, 2013  
+- [CTSA Ontology Workshop](https://ncorwiki.buffalo.edu/index.php/CTSA_Ontology_Workshop), February 11–12, 2013  
 
-- [The Role of Ontology in Big Cancer Data](/wiki/theroleofontologyinbigcancerdata), National Cancer Institute, Bethesda, MD, May 12-13, 2015
+## 2012
+- [Ontology for Intelligence, Defense, and Security](https://ncorwiki.buffalo.edu/index.php/Ontology_for_Intelligence,_Defense_and_Security), October 22, 2012  
+- [MUG Publication](https://forschung.medunigraz.at/fodok/suchen.publikationen_mug_autoren?sprache_in=de&menue_id_in=105&id_in=2004761&publikation_id_in=121555), July 22–25, 2012  
+- [Conference Listing (FOIS)](http://wikicfp.com/cfp/servlet/event.showcfp?eventid=18593&copyownerid=2), July 25–28, 2012  
+- [Immunology Ontologies and Their Applications](https://ncorwiki.buffalo.edu/index.php/Immunology_Ontologies_and_Their_Applications_in_Processing_Clinical_Data), June 11–13, 2012  
+- [Basic Formal Ontology and the Signature Discovery Ontology](https://ncorwiki.buffalo.edu/index.php/Basic_Formal_Ontology_and_the_Signature_Discovery_Ontology), May 1–2, 2012  
 
-- [CTS Ontology Workshop 2015](/wiki/ctsontologyworkshop2015), Ontology in Practice. 
-The Fourth Clinical and Translational Science Ontology Workshop.
-Charleston, SC, September 23-25, 2015
+## 2010
+- [The Future of the Electronic Health Record](https://ncorwiki.buffalo.edu/index.php/The_Future_of_the_Electronic_Health_Record), September 22, 2010  
 
-- [Symposium on Military Codes of Ethics](/wiki/symposiumonmilitarycodesofethics), Buffalo, NY 14260, November 2, 2015
+## 2009
+- [Command and Control Core Ontology Exchange](https://ncorwiki.buffalo.edu/index.php/Command_and_Control_Core_Ontology_Exchange_Meeting), January 15–16, 2009  
+- [From BFO to IAO](https://ncorwiki.buffalo.edu/index.php/From_BFO_to_IAO), July 22–23, 2009  
 
-See also [here](http://ncorwiki.buffalo.edu/index.php/Past_Events) and [here](http://www.bioontology.org/wiki/index.php/Dissemination_Wiki)
+## 2007
+- Proceedings only, November 28–29, 2007  
 
-## 2014 
+## 2006
+- [Ontology for the Intelligence Community](https://ebiquity.umbc.edu/conference/html/id/18/ontology-for-the-intelligence-community), November 30–December 1, 2006  
 
-- [Ontology and Imaging Informatics](http://ncorwiki.buffalo.edu/index.php/Third_CTS_Ontology_Workshop)**, Buffalo, NY, June 23-25, 2014
-
-- [Information Artifact Ontologies](/wiki/informationartifactontologies)**, Workshop organized as part of the [FOIS 2014](http://fois2014.inf.ufes.br/p/home.html) Conference, Rio de Janeiro, Brazil, September 22, 2014
-
-- [Buffalo Ontology Group Meeting](http://ncorwiki.buffalo.edu/index.php/Buffalo_Ontology_Group_Meeting_January_27,_2014)**, IHI, Buffalo, January 27, 2014
-
-- [Maurizio Ferraris: [The Ontology of Social Reality](http://ncorwiki.buffalo.edu/index.php/Maurizio_Ferraris), Buffalo, March 10, 2014
-
-- [Fabian Neuhaus: [Computational Creativity](http://ncorwiki.buffalo.edu/index.php/Fabian_Neuhaus), 
-CTRC, Buffalo, March 21, 2014
-
-## 2013 
-
-- [ImmPort](/wiki/immport): A Guide for Submitters**, workshop organized in conjunction with Rho Federal Systems Division, Chapel Hill, NC, October 9-10, 2013
-
-- [How to Advance Reusability of Immunology Data](/wiki/howtoadvancereusabilityofimmunologydata)**, Buffalo, July 23, 2013
-
-- [OGMS Workshop](/wiki/ogmsworkshop), co-located with ICBO 2013, Montreal. Co-located with the Fourth International Conference on Biomedical Ontologies ([ICBO2013](http://www.unbsj.ca/sase/csas/data/ws/icbo2013/)), July 10, 2013
-
-- [BFO 2.0 Meeting](/wiki/bfo20meeting), Montreal. Co-located with the Fourth International Conference on Biomedical Ontologies ([ICBO2013](http://www.unbsj.ca/sase/csas/data/ws/icbo2013/)), July 10, 2013
-
-- [OBO Foundry 101: Collaborative ontology development, tool support and semantic web](http://ncorwiki.buffalo.edu/index.php/2013_ICBO_OBO_tutorial)**, Montreal. Co-located with the Fourth International Conference on Biomedical Ontologies ([ICBO2013](http://www.unbsj.ca/sase/csas/data/ws/icbo2013/)), July 7, 2013
-
-- [Workshop on Definitions in Ontologies](http://definitionsinontologies.weebly.com/), Montreal. Co-located with the Fourth International Conference on Biomedical Ontologies ([ICBO2013](http://www.unbsj.ca/sase/csas/data/ws/icbo2013/)), July 7, 2013
-
-- [Summer School for Quantitative Systems Immunology](http://www.bu.edu/computationalimmunology/summerschool/index.html), Institute for Computing and Computational Science and Engineering, Boston University, Boston, MA. 
-For session on Immunology Ontology by Lindsay Cowell and Barry Smith, Tuesday June 11, 2013 see [ here](/wiki/immunologyontology), June 10-14, 2013.
-
-- [PRO-PO-GO Ontology Workshop](http://wiki.plantontology.org/index.php/PRO-PO-GO_Meeting)**, Buffalo, May 15-16, 2013
-
-- [Basic Formal Ontology Meeting](http://ncorwiki.buffalo.edu/index.php/2013_BFO_Meeting)**, Buffalo, May 13-14, 2013
-
-- [Ontologies for Information Integration](http://ncor.buffalo.edu/oi2/)**, Buffalo, April 18, 2013. 
-  - [Press coverage of this event](https://www.buffalo.edu/news/releases/2013/04/012.html)
-  - [Military Intelligence Tries To Tame Data 'Monster'](http://www.informationweek.com/government/security/military-intelligence-tries-to-tame-data/240152675)
-
-- [First ImmPort Ontology Group Web Conference](/wiki/firstimmportontologygroupwebconference), Buffalo and Stanford, April 8, 2013
-
-- [CTSA Ontology Workshop](/wiki/ctsaontologyworkshop), Orlando, February 11-12, 2013.
-
-## 2012 
-
-- [Ontology for Intelligence, Defense and Security](/wiki/ontologyforintelligencedefenseandsecurity), Tutorial, Conference on Semantic Technology for Intelligence, Defense and Security, George Mason University, Fairfax, VA, October 22, 2012
-
-- [Basic Formal Ontology 2.0 Preliminary Development Workshop](http://ncorwiki.buffalo.edu/index.php/Basic_Formal_Ontology_2.0), Center of Excellence in Bioinformatics and Life Sciences, National Center for Ontological Research. August 18-19, 2012
-
-- [International Conference on Biomedical Ontology](http://user.meduni-graz.at/stefan.schulz/icbofois2012/icbo.htm), Graz, Austria • July 22-25, 2012.
-
-- [Formal Ontology in Information Systems](http://user.meduni-graz.at/stefan.schulz/icbofois2012/icbo.htm)
-Graz, Austria • July 25-28, 2012.
-
-- [Immunology Ontologies and Their Applications in Processing Clinical Data](/wiki/immunologyontologiesandtheirapplicationsinprocessingclinicaldata), Buffalo, NY, June 11-13, 2012.
-
-- [Basic Formal Ontology and the Signature Discovery Ontology](/wiki/basicformalontologyandthesignaturediscoveryontology), Buffalo, May 1-2, 2012.
-
-- [Ontology Summit](http://ontolog.cim3.net/cgi-bin/wiki.pl?OntologySummit2012): Ontology for Big Systems, January-April, 2012
-
-## 2011 
-
-- [Workshop on Ontology Driven Implementation of Semantic Services for the Enterprise Environment: [ODISSEE](http://ncor.buffalo.edu/ODISSEE), Washington DC, April 12-13, 2011
-
-## 2010 
-
-- [An Introduction to Ontology Building](http://ncorwiki.buffalo.edu/index.php/An_Introduction_to_Ontology_Building) (October 23, 2010)
-
-- [The Future of the Electronic Health Record](/wiki/thefutureoftheelectronichealthrecord) (September 22, 2010).
-
-## 2009 
-
-- [Command and Control Core Ontology Exchange Meeting](/wiki/commandandcontrolcoreontologyexchangemeeting), National Center for Ontological Research and Army Net-Centric Data Strategy Center of Excellence, January 15-16, 2009, Buffalo NY
-
-- [From BFO to IAO](/wiki/frombfotoiao), July 22-23, 2009
-
-- [International Conference on Biomedical Ontology](http://icbo.buffalo.edu/2009), July 24-26, 2009
-
-- [Ontology for the Intelligence Community: Towards Effective Exploitation and Integration of Intelligence Resources](http://ceur-ws.org/Vol-555/), October 21-22, 2009, Fairfax, VA
-
-## 2008 
-
-- [Ontology for the Intelligence Community: Towards Effective Exploitation and Integration of Intelligence Resources](http://ceur-ws.org/Vol-440/), December 3-4, 2008, Columbia, MD 
-
-## 2007 
-
-- [Ontology for the Intelligence Community: Towards Effective Exploitation and Integration of Intelligence Resources](http://ncor.buffalo.edu/oic2007/Program.pdf), November 28-29, 2007, Columbia, MD. [Proceedings](http://ceur-ws.org/Vol-299/)
-
-## 2006 
-
-- [Ontology for the Intelligence Community: Towards Effective Exploitation and Integration of Intelligence Resources](http://ncor.buffalo.edu/oic2006), Columbia, MD, November 30-December 1, 2006
-
-## 2005 
-
-- [NCOR Inaugural Event](http://ncor.buffalo.edu/inaugural/index.htm), October 27, 2005, Buffalo, NY. 
-
-- [NCOR Inaugural Event](http://ncor.buffalo.edu/inaugural/index.htm), October 27, 2005, Buffalo, NY. 
-
-- [Associated Workshop on Bio-Ontologies](http://ontology.buffalo.edu/05/bio-ontologiesOct05/bio-ontologies.pdf), October 28, 2005, Buffalo, NY. For associated presentations see [here](http://ontology.buffalo.edu/05/bio-ontologiesOct05/).
-
-- [NCBO Dissemination and training events](https://www.bioontology.org/wiki/index.php/Meetings_and_Events) organized under the auspices of the [National Center for Biomedical Ontology](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3277625/).
+## 2005
+- [University News – Barry Smith](https://ed.buffalo.edu/about.host.html/content/shared/university/news/news-center-releases/2005/10/7600.detail.html), October 27, 2005


### PR DESCRIPTION
- Correct all broken and missing links (based on archival sources and current URLs)
- Fix malformed markdown syntax (e.g., extra asterisks, misplaced brackets)
- Standardize formatting across all years from 2005 to 2024
- Preserve original working links and structure