### PR TITLE
fix(config): remove unsupported metadata field and migrate meta tags …

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,8 +17,6 @@ const config = {
   projectName: 'NCOR-Network',
   trailingSlash: false,
 
-  // ✨ REMOVED from here (was causing the error): metadata
-
   onBrokenLinks: 'ignore',
   onBrokenMarkdownLinks: 'warn',
 
@@ -71,16 +69,6 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      // ✅ Put global <meta> tags here in v3:
-      metadata: [
-        {
-          name: 'description',
-          content:
-            'NCOR is an international non-profit fostering ontology research, education, and interoperability for robust AI and data systems.',
-        },
-        { property: 'og:site_name', content: 'NCOR Network' },
-      ],
-
       image: 'img/ncor-network-logo.png',
       navbar: {
         title: 'NCOR',
@@ -229,7 +217,9 @@ const config = {
       type: 'text/css',
     },
   ],
+
   headTags: [
+    // Scripts
     {
       tagName: 'script',
       attributes: {
@@ -242,10 +232,22 @@ const config = {
       attributes: { type: 'text/javascript' },
       innerHTML: `
         (function(){
-          emailjs.init("YOUR_USER_ID"); // Replace with your actual EmailJS user ID
+          // TODO: replace with your actual EmailJS user ID or remove if unused
+          emailjs.init("YOUR_USER_ID");
         })();
       `,
     },
+
+    // Global meta tags (migrated from themeConfig.metadata)
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'description',
+        content:
+          'NCOR is an international non-profit fostering ontology research, education, and interoperability for robust AI and data systems.',
+      },
+    },
+    { tagName: 'meta', attributes: { property: 'og:site_name', content: 'NCOR Network' } },
   ],
 };
 


### PR DESCRIPTION
…to headTags

- Removed `themeConfig.metadata` (deprecated in Docusaurus v3).
- Moved global <meta> tags (description, og:site_name) into top-level `headTags`.
- Preserved `themeConfig.image` for default OG image handling.

This change fixes the build error:
  "These field(s) ("metadata",) are not recognized in docusaurus.config.js" and ensures meta tags are still applied correctly in the site head.